### PR TITLE
Init Diffable interface for better equality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,122 @@ func TestScript(t *testing.T) {
 	RunTests(t, "testdata/*.star", globals)
 }
 ```
+
+## test
+
+### test·error
+
+`t.error(msg)` reports the error msg to the test runner.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| msg | any | Message. |
+
+### test·fail
+
+`t.fail()` fails the test and halts test running.
+
+### test·fatal
+
+`t.fatal(msg)` reports the error msg to the test runner, and fails the test.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| msg | any | Message. |
+
+### test·freeze
+
+`t.freeze(val)` freze .
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| val | any | Value to freeze. |
+
+### test·run
+
+`t.run(subtest)` run .
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| subtest | func | Function to run as a subtest. |
+
+### test·skip
+
+`t.skip()` skips the current test.
+
+### test·equal
+
+`t.equal(a, b)` compares two values of the same type are equal.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| a | T | Value expected. |
+| b | T | Value given. |
+
+### test·not_equal
+
+`t.not_equal(a, b)` compares two values of the same type are not equal, r
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| a | Value | Value expected. |
+| b | Value | Value given. |
+
+### test·less_than
+
+`t.less_than(a, b)` compares two values of the same type are less than.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| a | Value | Value expected. |
+| b | Value | Value given. |
+
+### test·true
+
+`t.true(a, msg)` checks truthyness reporting the message if falsy.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| a | Value | Value expected to be truthy. |
+| msg | String | Message to report on falsyness. |
+
+### test·contains
+
+`t.contains(a, b)` checks `b` is in `a`.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| a | Iterable | Iterable item. |
+| b | Value | Value expected. |
+
+| msg | any | Message to report on error. |
+
+### test·fails
+
+`t.fails(f, pattern)` runs the function and checks the returned error matches the regex pattern.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| f | func | Value to run. |
+| pattern | string | Regex pattern to match. |
+
+
+## bench
+
+Bench is a superset of test. All attributes are included plus the following.
+
+### bench·restart
+
+`b.restart()` the benchmark clock.
+
+### bench·start
+
+`b.start()` the benchmark clock.
+
+### bench·stop
+
+`b.stop()` the benchmark clock.
+
+### bench·n
+
+`b.n` returns the current benchmark iteration size.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func TestScript(t *testing.T) {
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| msg | any | Message. |
+| msg | string | Message. |
 
 ### test·fail
 
@@ -55,23 +55,24 @@ func TestScript(t *testing.T) {
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| msg | any | Message. |
+| msg | value | Message. |
 
 ### test·freeze
 
-`t.freeze(val)` freze .
+`t.freeze(val)` the value, for testing freeze behaviour.
+All mutations after freeze should fail.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| val | any | Value to freeze. |
+| val | value | Value to freeze. |
 
 ### test·run
 
-`t.run(subtest)` run .
+`t.run(subtest)` runs the function with a test instance as the first arg.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| subtest | func | Function to run as a subtest. |
+| subtest | function | Function to run as a subtest. |
 
 ### test·skip
 
@@ -80,11 +81,12 @@ func TestScript(t *testing.T) {
 ### test·equal
 
 `t.equal(a, b)` compares two values of the same type are equal.
+If the value is diffable it will report the difference between the two.
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| a | T | Value expected. |
-| b | T | Value given. |
+| a | value | Value expected. |
+| b | value | Value given. |
 
 ### test·not_equal
 
@@ -92,8 +94,8 @@ func TestScript(t *testing.T) {
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| a | Value | Value expected. |
-| b | Value | Value given. |
+| a | value | Value expected. |
+| b | value | Value given. |
 
 ### test·less_than
 
@@ -101,8 +103,8 @@ func TestScript(t *testing.T) {
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| a | Value | Value expected. |
-| b | Value | Value given. |
+| a | value | Value expected. |
+| b | value | Value given. |
 
 ### test·true
 
@@ -110,8 +112,8 @@ func TestScript(t *testing.T) {
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| a | Value | Value expected to be truthy. |
-| msg | String | Message to report on falsyness. |
+| a | value | Value expected to be truthy. |
+| msg | string | Message to report on falsyness. |
 
 ### test·contains
 
@@ -119,10 +121,8 @@ func TestScript(t *testing.T) {
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| a | Iterable | Iterable item. |
-| b | Value | Value expected. |
-
-| msg | any | Message to report on error. |
+| a | iterable | Iterable item. |
+| b | value | Value expected. |
 
 ### test·fails
 
@@ -130,7 +130,7 @@ func TestScript(t *testing.T) {
 
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
-| f | func | Value to run. |
+| f | function | value to run. |
 | pattern | string | Regex pattern to match. |
 
 

--- a/bench.go
+++ b/bench.go
@@ -59,12 +59,15 @@ var benchAttrs = map[string]benchAttr{
 	"freeze": func(b *Bench) starlark.Value { return method{b, "freeze", freeze} },
 	"skip":   func(b *Bench) starlark.Value { return tmethod{b, "skip", b.b, tskip} },
 
-	"eq":       func(b *Bench) starlark.Value { return tmethod{b, "eq", b.b, teq} },
-	"ne":       func(b *Bench) starlark.Value { return tmethod{b, "ne", b.b, tne} },
-	"true":     func(b *Bench) starlark.Value { return tmethod{b, "true", b.b, ttrue} },
-	"lt":       func(b *Bench) starlark.Value { return tmethod{b, "lt", b.b, tlt} },
-	"contains": func(b *Bench) starlark.Value { return tmethod{b, "contains", b.b, tcontains} },
-	"fails":    func(b *Bench) starlark.Value { return tmethod{b, "fails", b.b, tfails} },
+	"eq":        func(b *Bench) starlark.Value { return tmethod{b, "eq", b.b, teq} },
+	"equal":     func(b *Bench) starlark.Value { return tmethod{b, "eq", b.b, teq} },
+	"ne":        func(b *Bench) starlark.Value { return tmethod{b, "ne", b.b, tne} },
+	"not_equal": func(b *Bench) starlark.Value { return tmethod{b, "ne", b.b, tne} },
+	"true":      func(b *Bench) starlark.Value { return tmethod{b, "true", b.b, ttrue} },
+	"lt":        func(b *Bench) starlark.Value { return tmethod{b, "lt", b.b, tlt} },
+	"less_than": func(b *Bench) starlark.Value { return tmethod{b, "lt", b.b, tlt} },
+	"contains":  func(b *Bench) starlark.Value { return tmethod{b, "contains", b.b, tcontains} },
+	"fails":     func(b *Bench) starlark.Value { return tmethod{b, "fails", b.b, tfails} },
 }
 
 func (b *Bench) restart(_ *starlark.Thread, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {

--- a/diff.go
+++ b/diff.go
@@ -1,0 +1,15 @@
+package starlarkassert
+
+import "go.starlark.net/starlark"
+
+// A Diffable is a value that can report it's difference.
+type Diffable interface {
+	starlark.Value
+	starlark.Comparable
+
+	// DiffSameType compares a value of the same Type().
+	// Returns a human-readable report of the difference between the two values.
+	// Returns an empty string if the two values are equal.
+	// Implementation should be similar to cmp.Diff().
+	DiffSameType(y starlark.Value) (string, error)
+}

--- a/diff.go
+++ b/diff.go
@@ -4,7 +4,6 @@ import "go.starlark.net/starlark"
 
 // A Diffable is a value that can report it's difference.
 type Diffable interface {
-	starlark.Value
 	starlark.Comparable
 
 	// DiffSameType compares a value of the same Type().

--- a/impl.go
+++ b/impl.go
@@ -120,7 +120,7 @@ func teq(t testing.TB, _ *Thread, args Tuple, kwargs []Tuple) (Value, error) {
 		if v, diffOk := x.(Diffable); diffOk {
 			str, err := v.DiffSameType(y)
 			if err != nil {
-				return True, err
+				return nil, err
 			}
 			t.Error(str)
 		} else {

--- a/test.go
+++ b/test.go
@@ -44,12 +44,15 @@ var testAttrs = map[string]testAttr{
 	"run":    func(t *Test) starlark.Value { return method{t, "run", t.run} },
 	"skip":   func(t *Test) starlark.Value { return tmethod{t, "skip", t.t, tskip} },
 
-	"eq":       func(t *Test) starlark.Value { return tmethod{t, "eq", t.t, teq} },
-	"ne":       func(t *Test) starlark.Value { return tmethod{t, "ne", t.t, tne} },
-	"true":     func(t *Test) starlark.Value { return tmethod{t, "true", t.t, ttrue} },
-	"lt":       func(t *Test) starlark.Value { return tmethod{t, "lt", t.t, tlt} },
-	"contains": func(t *Test) starlark.Value { return tmethod{t, "contains", t.t, tcontains} },
-	"fails":    func(t *Test) starlark.Value { return tmethod{t, "fails", t.t, tfails} },
+	"eq":        func(t *Test) starlark.Value { return tmethod{t, "eq", t.t, teq} },
+	"equal":     func(t *Test) starlark.Value { return tmethod{t, "eq", t.t, teq} },
+	"ne":        func(t *Test) starlark.Value { return tmethod{t, "ne", t.t, tne} },
+	"not_equal": func(t *Test) starlark.Value { return tmethod{t, "ne", t.t, tne} },
+	"true":      func(t *Test) starlark.Value { return tmethod{t, "true", t.t, ttrue} },
+	"lt":        func(t *Test) starlark.Value { return tmethod{t, "lt", t.t, tlt} },
+	"less_than": func(t *Test) starlark.Value { return tmethod{t, "lt", t.t, tlt} },
+	"contains":  func(t *Test) starlark.Value { return tmethod{t, "contains", t.t, tcontains} },
+	"fails":     func(t *Test) starlark.Value { return tmethod{t, "fails", t.t, tfails} },
 }
 
 func (t *Test) Attr(name string) (starlark.Value, error) {


### PR DESCRIPTION
`t.equal(...)` now tries to check the difference by calling `DiffSameType` on the value.